### PR TITLE
Update seasonal collection banners and remove content

### DIFF
--- a/index.html
+++ b/index.html
@@ -615,12 +615,9 @@
     <section class="collection-page-section" id="collectionPage" style="display: none;">
         <div class="container">
             <!-- Back Navigation -->
-            <div class="collection-nav">
-                <button class="back-to-home-btn" id="backToHome">
-                    <i class="fas fa-arrow-left"></i>
-                    Back to Home
-                </button>
-            </div>
+            <button class="back-to-home-btn" id="backToHome">
+                <i class="fas fa-arrow-left"></i> Back to Home
+            </button>
 
 
             <!-- Cross-Collection Navigation -->

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
         }
 
         /* Keep overlay behaviour already defined in styles.css */
-        .collection-hero-overlay { position: absolute; left: 0; right: 0; bottom: 0; top: 2px; background: rgba(0,0,0,0.25); z-index:1; border-radius:20px; }
+        .collection-hero-overlay { position: absolute; left: 0; right: 0; bottom: 0; top: 2px; background: rgba(0,0,0,0.25); z-index:1; border-radius:20px; background-image: url('https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2F094de4b2359d4befae73b51ab6025956'); background-repeat: no-repeat; background-position: center; background-size: cover; }
     </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -637,6 +637,16 @@
                 </div>
             </div>
 
+            <!-- Cross-Collection Navigation -->
+            <div class="collection-navigation">
+                <h3>Shop Collections</h3>
+                <div class="collection-tabs">
+                    <button class="collection-tab active" data-collection="winter">Winter</button>
+                    <button class="collection-tab" data-collection="spring">Spring</button>
+                    <button class="collection-tab" data-collection="summer">Summer</button>
+                </div>
+            </div>
+
             <!-- Top Picks for Winter -->
             <div class="winter-highlights">
                 <div class="highlight-section">

--- a/index.html
+++ b/index.html
@@ -624,15 +624,8 @@
                 <div class="collection-hero spring-hero spring-hero-bg">
                     <div class="collection-hero-overlay"></div>
                     <div class="spring-hero-inner">
-                        <div class="spring-hero-text">
-                            <div class="badge">New Arrival</div>
-                            <h1 class="collection-title">Spring Collection 2025</h1>
-                            <p class="collection-tagline">Fresh styles for the new season ahead</p>
-                            <button class="collection-cta" onclick="window.location.href='spring-collection.html'">Shop Spring</button>
-                        </div>
-                        <div class="spring-hero-visual">
-                            <img src="https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2F199ff3be0ea14a5d9d45748644314a9a?format=webp&width=800" alt="Spring Model" class="spring-model-image">
-                        </div>
+                        <div class="spring-hero-text"></div>
+                        <div class="spring-hero-visual"></div>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -578,7 +578,7 @@
 
             <!-- Collection Header/Banner Section -->
             <div class="collection-header">
-                <div class="collection-hero" style="background-image: url('https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2F3c6c18688cb242a2b70afc40d14e9e69'); background-repeat: no-repeat; background-position: center; background-size: cover; position: relative; min-height: 400px; height: 450px; border-radius: 20px; overflow: hidden;">
+                <div class="collection-hero" style="background-image: url('https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2Fc4019445ace94cc59e8b63356e89694e?format=webp&width=1200'); background-repeat: no-repeat; background-position: center; background-size: cover; position: relative; min-height: 400px; height: 450px; border-radius: 20px; overflow: hidden;">
                     <div style="font-weight:400"></div>
                 </div>
             </div>
@@ -812,7 +812,7 @@
         <div class="container">
             <h2 class="section-title">What's Trending</h2>
             <div class="trending-tabs">
-                <button class="trending-tab active" data-trend="hot">What's Hot ����</button>
+                <button class="trending-tab active" data-trend="hot">What's Hot 🔥</button>
                 <button class="trending-tab" data-trend="viewed">Most Viewed 👁️</button>
                 <button class="trending-tab" data-trend="sellers">Best Sellers ⭐</button>
             </div>

--- a/index.html
+++ b/index.html
@@ -47,6 +47,52 @@
             }catch(e){ console.warn('Dev guard init error', e); }
         })();
     </script>
+    <style>
+        /* Spring collection hero background converted from inline styles */
+        .spring-hero-bg {
+            background-image: url('https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2F199ff3be0ea14a5d9d45748644314a9a?format=webp&width=800');
+            background-repeat: no-repeat;
+            background-position: center;
+            background-size: cover;
+            position: relative;
+            min-height: 420px;
+            height: 480px;
+            border-radius: 20px;
+            overflow: hidden;
+        }
+
+        .spring-hero-inner {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 2rem;
+            padding: 2rem;
+        }
+
+        .spring-hero-text {
+            max-width: 56%;
+            color: white;
+            z-index: 2;
+        }
+
+        .spring-hero-visual {
+            max-width: 44%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 2;
+        }
+
+        .spring-model-image {
+            width: 100%;
+            height: auto;
+            object-fit: cover;
+            border-radius: 12px;
+        }
+
+        /* Keep overlay behaviour already defined in styles.css */
+        .collection-hero-overlay { position: absolute; inset: 0; background: rgba(0,0,0,0.25); z-index:1; border-radius:20px; }
+    </style>
 </head>
 <body>
     <!-- Flash Screen -->

--- a/index.html
+++ b/index.html
@@ -599,7 +599,7 @@
                             <button class="collection-cta" onclick="window.location.href='spring-collection.html'">Shop Spring</button>
                         </div>
                         <div class="spring-hero-visual">
-                            <img src="https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2Fc4e20bc9665d428fa8ea5a83b64eecb2?format=webp&width=800" alt="Spring Model" class="spring-model-image">
+                            <img src="https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2F199ff3be0ea14a5d9d45748644314a9a?format=webp&width=800" alt="Spring Model" class="spring-model-image">
                         </div>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -797,19 +797,6 @@
                         </div>
                     </div>
 
-                    <!-- Shop Best Deals CTA -->
-                    <div class="best-deals-cta">
-                        <div class="deals-cta-content">
-                            <div class="deals-cta-text">
-                                <h3>Don't Miss Out! 🔥</h3>
-                                <p>Discover exclusive winter deals and limited-time offers on premium fashion</p>
-                            </div>
-                            <button class="shop-best-deals-btn">
-                                <span>Shop Best Deals</span>
-                                <i class="fas fa-arrow-right"></i>
-                            </button>
-                        </div>
-                    </div>
                 </div>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -589,7 +589,7 @@
 
 
             <div class="collection-header">
-                <div class="collection-hero spring-hero" style="background-image: url('https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2Fc4e20bc9665d428fa8ea5a83b64eecb2?format=webp&width=1200'); background-repeat: no-repeat; background-position: center; background-size: cover; position: relative; min-height: 420px; height: 480px; border-radius: 20px; overflow: hidden;">
+                <div class="collection-hero spring-hero spring-hero-bg">
                     <div class="collection-hero-overlay"></div>
                     <div class="spring-hero-inner">
                         <div class="spring-hero-text">

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
     <style>
         /* Spring collection hero background converted from inline styles */
         .spring-hero-bg {
-            background-image: url('https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2F199ff3be0ea14a5d9d45748644314a9a?format=webp&width=800');
+            background-image: url('https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2Fc4019445ace94cc59e8b63356e89694e?format=webp&width=1200');
             background-repeat: no-repeat;
             background-position: center;
             background-size: cover;
@@ -1120,7 +1120,7 @@
                     <div class="colorful-product-info">
                         <h3 class="colorful-product-title">Teal Cotton Casual Shirt</h3>
                         <div class="product-rating">
-                            <span class="stars">★★★���★</span>
+                            <span class="stars">★★★����★</span>
                         </div>
                         <div class="colorful-product-price">
                             <span class="current-price">$55</span>

--- a/index.html
+++ b/index.html
@@ -590,7 +590,6 @@
                     <button class="collection-tab active" data-collection="winter">Winter</button>
                     <button class="collection-tab" data-collection="spring">Spring</button>
                     <button class="collection-tab" data-collection="summer">Summer</button>
-                    <button class="collection-tab" data-collection="autumn">Autumn</button>
                 </div>
             </div>
 
@@ -813,7 +812,7 @@
         <div class="container">
             <h2 class="section-title">What's Trending</h2>
             <div class="trending-tabs">
-                <button class="trending-tab active" data-trend="hot">What's Hot 🔥</button>
+                <button class="trending-tab active" data-trend="hot">What's Hot ����</button>
                 <button class="trending-tab" data-trend="viewed">Most Viewed 👁️</button>
                 <button class="trending-tab" data-trend="sellers">Best Sellers ⭐</button>
             </div>

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
         }
 
         /* Keep overlay behaviour already defined in styles.css */
-        .collection-hero-overlay { position: absolute; inset: 0; background: rgba(0,0,0,0.25); z-index:1; border-radius:20px; }
+        .collection-hero-overlay { position: absolute; left: 0; right: 0; bottom: 0; top: 2px; background: rgba(0,0,0,0.25); z-index:1; border-radius:20px; }
     </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -578,7 +578,7 @@
 
             <!-- Collection Header/Banner Section -->
             <div class="collection-header">
-                <div class="collection-hero" style="background-image: url('https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2Fb5036b89f26247f2ac15d5c9b1cd7c3e'); background-repeat: no-repeat; background-position: center; background-size: cover; position: relative; min-height: 300px; border-radius: 20px; overflow: hidden;">
+                <div class="collection-hero" style="background-image: url('https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2F3c6c18688cb242a2b70afc40d14e9e69'); background-repeat: no-repeat; background-position: center; background-size: cover; position: relative; min-height: 400px; height: 450px; border-radius: 20px; overflow: hidden;">
                     <div style="font-weight:400"></div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -588,6 +588,23 @@
             </div>
 
 
+            <div class="collection-header">
+                <div class="collection-hero spring-hero" style="background-image: url('https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2Fc4e20bc9665d428fa8ea5a83b64eecb2?format=webp&width=1200'); background-repeat: no-repeat; background-position: center; background-size: cover; position: relative; min-height: 420px; height: 480px; border-radius: 20px; overflow: hidden;">
+                    <div class="collection-hero-overlay"></div>
+                    <div class="spring-hero-inner">
+                        <div class="spring-hero-text">
+                            <div class="badge">New Arrival</div>
+                            <h1 class="collection-title">Spring Collection 2025</h1>
+                            <p class="collection-tagline">Fresh styles for the new season ahead</p>
+                            <button class="collection-cta" onclick="window.location.href='spring-collection.html'">Shop Spring</button>
+                        </div>
+                        <div class="spring-hero-visual">
+                            <img src="https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2Fc4e20bc9665d428fa8ea5a83b64eecb2?format=webp&width=800" alt="Spring Model" class="spring-model-image">
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <!-- Top Picks for Winter -->
             <div class="winter-highlights">
                 <div class="highlight-section">

--- a/index.html
+++ b/index.html
@@ -620,17 +620,6 @@
             </button>
 
 
-            <!-- Cross-Collection Navigation -->
-            <div class="collection-navigation">
-                <h3>Shop Collections</h3>
-                <div class="collection-tabs">
-                    <button class="collection-tab active" data-collection="winter">Winter</button>
-                    <button class="collection-tab" data-collection="spring">Spring</button>
-                    <button class="collection-tab" data-collection="summer">Summer</button>
-                </div>
-            </div>
-
-
             <div class="collection-header">
                 <div class="collection-hero spring-hero spring-hero-bg">
                     <div class="collection-hero-overlay"></div>

--- a/index.html
+++ b/index.html
@@ -579,7 +579,12 @@
             <!-- Collection Header/Banner Section -->
             <div class="collection-header">
                 <div class="collection-hero" style="background-image: url('https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2Fb5036b89f26247f2ac15d5c9b1cd7c3e'); background-repeat: no-repeat; background-position: center; background-size: cover; position: relative; min-height: 300px; border-radius: 20px; overflow: hidden;">
-                    <!-- hero content intentionally removed per diff -->
+                    <div class="collection-hero-overlay"></div>
+                    <div class="collection-hero-content">
+                        <h1 class="collection-title" id="collectionTitle">Winter Collection 2025</h1>
+                        <p class="collection-tagline" id="collectionTagline">Explore cozy coats, chic sweaters, and stylish accessories designed to keep you warm and elegant this season.</p>
+                        <button class="collection-cta" onclick="window.location.href='winter-sale.html'">Shop Winter</button>
+                    </div>
                 </div>
             </div>
 

--- a/index.html
+++ b/index.html
@@ -578,14 +578,8 @@
 
             <!-- Collection Header/Banner Section -->
             <div class="collection-header">
-                <div class="collection-hero">
-                    <div class="collection-hero-content">
-                        <h1 class="collection-title" id="collectionTitle">Winter Collection 2025</h1>
-                        <p class="collection-tagline" id="collectionTagline">Stay stylish & cozy this winter</p>
-                    </div>
-                    <div class="collection-hero-image" id="collectionHeroImage">
-                        <img src="https://cdn.builder.io/api/v1/image/assets%2Fa91527f2fe264920accbd14578b2df55%2F15723a5439104d63b98f8303a1efcea3?format=webp&width=1200" alt="Winter Collection" class="hero-image">
-                    </div>
+                <div class="collection-hero" style="background-image: url('https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2Fb5036b89f26247f2ac15d5c9b1cd7c3e'); background-repeat: no-repeat; background-position: center; background-size: cover; position: relative; min-height: 300px; border-radius: 20px; overflow: hidden;">
+                    <!-- hero content intentionally removed per diff -->
                 </div>
             </div>
 

--- a/index.html
+++ b/index.html
@@ -319,23 +319,6 @@
                     <div class="geometric-shape shape-2"></div>
                     <div class="geometric-shape shape-3"></div>
                 </div>
-                <div class="slide-content">
-                    <div class="slide-left">
-                        
-                        <div class="collection-badge">New Arrival</div>
-                        <h1 class="slide-title">
-                            <span class="title-main">FASHION</span>
-                            <span class="title-sub">SEASONAL COLLECTION</span>
-                        </h1>
-                        <p class="slide-description">Discover the latest trends in fashion with our curated seasonal collection featuring premium designs and contemporary styles.</p>
-                        <button class="slide-cta-btn">Shop Collection</button>
-                    </div>
-                    <div class="slide-right">
-                        <div class="model-image">
-                            <img src="https://images.unsplash.com/photo-1515372039744-b8f02a3ae446?w=400&h=600&fit=crop" alt="Fashion Model" class="model-img">
-                        </div>
-                    </div>
-                </div>
             </div>
 
             <!-- Slide 2 -->
@@ -345,23 +328,6 @@
                     <div class="geometric-shape shape-2"></div>
                     <div class="geometric-shape shape-3"></div>
                 </div>
-                <div class="slide-content">
-                    <div class="slide-left">
-                        
-                        <div class="collection-badge">Trending Now</div>
-                        <h1 class="slide-title">
-                            <span class="title-main">WINTER</span>
-                            <span class="title-sub">COLLECTION 2024</span>
-                        </h1>
-                        <p class="slide-description">Embrace the season with our exclusive winter collection featuring cozy yet stylish pieces perfect for the modern wardrobe.</p>
-                        <button class="slide-cta-btn">Explore Winter</button>
-                    </div>
-                    <div class="slide-right">
-                        <div class="model-image">
-                            <img src="https://cdn.builder.io/api/v1/image/assets%2F83fcd0ffeb504b4897e3b397a63b44f0%2F8dab5969bddd4da19d923574ad4a29e7?format=webp&width=800" alt="Winter Fashion Model" class="model-img">
-                        </div>
-                    </div>
-                </div>
             </div>
 
             <!-- Slide 3 -->
@@ -370,23 +336,6 @@
                     <div class="geometric-shape shape-1"></div>
                     <div class="geometric-shape shape-2"></div>
                     <div class="geometric-shape shape-3"></div>
-                </div>
-                <div class="slide-content">
-                    <div class="slide-left">
-                        
-                        <div class="collection-badge">Limited Edition</div>
-                        <h1 class="slide-title">
-                            <span class="title-main">DESIGNER</span>
-                            <span class="title-sub">EXCLUSIVE PIECES</span>
-                        </h1>
-                        <p class="slide-description">Discover our exclusive designer collaborations featuring unique pieces that define luxury and sophistication in modern fashion.</p>
-                        <button class="slide-cta-btn">Shop Exclusive</button>
-                    </div>
-                    <div class="slide-right">
-                        <div class="model-image">
-                            <img src="https://images.unsplash.com/photo-1581803118522-7b72a50f7e9f?w=400&h=600&fit=crop" alt="Designer Fashion Model" class="model-img">
-                        </div>
-                    </div>
                 </div>
             </div>
 

--- a/index.html
+++ b/index.html
@@ -579,12 +579,7 @@
             <!-- Collection Header/Banner Section -->
             <div class="collection-header">
                 <div class="collection-hero" style="background-image: url('https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2Fb5036b89f26247f2ac15d5c9b1cd7c3e'); background-repeat: no-repeat; background-position: center; background-size: cover; position: relative; min-height: 300px; border-radius: 20px; overflow: hidden;">
-                    <div class="collection-hero-overlay"></div>
-                    <div class="collection-hero-content">
-                        <h1 class="collection-title" id="collectionTitle">Winter Collection 2025</h1>
-                        <p class="collection-tagline" id="collectionTagline">Explore cozy coats, chic sweaters, and stylish accessories designed to keep you warm and elegant this season.</p>
-                        <button class="collection-cta" onclick="window.location.href='winter-sale.html'">Shop Winter</button>
-                    </div>
+                    <div style="font-weight:400"></div>
                 </div>
             </div>
 

--- a/index.html
+++ b/index.html
@@ -576,12 +576,6 @@
                 </button>
             </div>
 
-            <!-- Collection Header/Banner Section -->
-            <div class="collection-header">
-                <div class="collection-hero" style="background-image: url('https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2Fc4019445ace94cc59e8b63356e89694e?format=webp&width=1200'); background-repeat: no-repeat; background-position: center; background-size: cover; position: relative; min-height: 400px; height: 450px; border-radius: 20px; overflow: hidden;">
-                    <div style="font-weight:400"></div>
-                </div>
-            </div>
 
             <!-- Cross-Collection Navigation -->
             <div class="collection-navigation">

--- a/script.js
+++ b/script.js
@@ -3933,10 +3933,20 @@ function loadCollectionContent(collectionType) {
     const collectionTitle = document.getElementById('collectionTitle');
     const collectionTagline = document.getElementById('collectionTagline');
     const collectionHeroImage = document.querySelector('#collectionHeroImage img');
+    const collectionHero = document.querySelector('.collection-hero');
 
     if (collectionTitle) collectionTitle.textContent = collectionData.title;
     if (collectionTagline) collectionTagline.textContent = collectionData.tagline;
-    if (collectionHeroImage) collectionHeroImage.src = collectionData.heroImage;
+
+    // If there is an <img> inside #collectionHeroImage set its src, otherwise set the .collection-hero background-image
+    if (collectionHeroImage) {
+        collectionHeroImage.src = collectionData.heroImage;
+    } else if (collectionHero) {
+        collectionHero.style.backgroundImage = `url('${collectionData.heroImage}')`;
+        collectionHero.style.backgroundRepeat = 'no-repeat';
+        collectionHero.style.backgroundPosition = 'center';
+        collectionHero.style.backgroundSize = 'cover';
+    }
 
     // Update active collection tab
     const collectionTabs = document.querySelectorAll('.collection-tab');

--- a/script.js
+++ b/script.js
@@ -3969,7 +3969,7 @@ function getCollectionData(collectionType) {
         winter: {
             title: 'Winter Collection ❄️',
             tagline: 'Explore cozy coats, chic sweaters, and stylish accessories designed to keep you warm and elegant this season.',
-            heroImage: 'https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2F3f2c6aba195c4e98b9eae1efd859a679?format=webp&width=1200',
+            heroImage: 'https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2Fdc3d010965634f2684d469eb7af5115a?format=webp&width=1200',
             theme: 'winter'
         },
         spring: {
@@ -4049,7 +4049,7 @@ function generateCollectionProducts(collectionType) {
         { name: 'Cashmere Turtleneck Sweater', price: 2899, category: 'sweaters', rating: '★★★★☆', image: 'https://cdn.builder.io/api/v1/image/assets%2F4797038dfeab418e80d0045aa34c21d8%2Fcd41764914f3435db0789865df8be918?format=webp&width=400' },
         { name: 'Quilted Puffer Jacket', price: 3499, category: 'jackets', rating: '★��★★★', image: 'https://cdn.builder.io/api/v1/image/assets%2F4797038dfeab418e80d0045aa34c21d8%2F849f7f09fb5840d7b25e7cdc865cdaa9?format=webp&width=400' },
         { name: 'Knit Winter Dress', price: 2199, category: 'dresses', rating: '★★★★☆', image: 'https://cdn.builder.io/api/v1/image/assets%2F4797038dfeab418e80d0045aa34c21d8%2F9915d20cfed848ec961a57e0b81de98d?format=webp&width=400' },
-        { name: 'Leather Winter Gloves', price: 899, category: 'accessories', rating: '★★�����★★', image: 'https://cdn.builder.io/api/v1/image/assets%2F4797038dfeab418e80d0045aa34c21d8%2F081e58fb86c541a9af4297f57d3809c0?format=webp&width=400' },
+        { name: 'Leather Winter Gloves', price: 899, category: 'accessories', rating: '★★���★★', image: 'https://cdn.builder.io/api/v1/image/assets%2F4797038dfeab418e80d0045aa34c21d8%2F081e58fb86c541a9af4297f57d3809c0?format=webp&width=400' },
         { name: 'Designer Wool Scarf', price: 1299, category: 'accessories', rating: '★���★★☆', image: 'https://cdn.builder.io/api/v1/image/assets%2F4797038dfeab418e80d0045aa34c21d8%2F5eccc65dc3744b36bfe1a6bc749e0af5?format=webp&width=400' },
         { name: 'Premium Bomber Jacket', price: 3899, category: 'jackets', rating: '★��★★★', image: 'https://cdn.builder.io/api/v1/image/assets%2F4797038dfeab418e80d0045aa34c21d8%2F8c2b221fa19b42968096df5cef83e949?format=webp&width=400' },
         { name: 'Merino Wool Cardigan', price: 2499, category: 'sweaters', rating: '★★★★☆', image: 'https://cdn.builder.io/api/v1/image/assets%2F4797038dfeab418e80d0045aa34c21d8%2F341ff6d502c545c4b3ada70308c85526?format=webp&width=400' }

--- a/script.js
+++ b/script.js
@@ -3988,7 +3988,7 @@ function getCollectionData(collectionType) {
         summer: {
             title: 'Summer Collection 2025',
             tagline: 'Light, breezy styles for sunny days',
-            heroImage: 'https://cdn.builder.io/api/v1/image/assets%2Fa91527f2fe264920accbd14578b2df55%2Fb0bd47d0cef64e398781bc1c01fbde2e?format=webp&width=1200',
+            heroImage: 'https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2Faed3a1db5455433fac0f9847e6059a78?format=webp&width=1200',
             theme: 'summer'
         },
         exclusive: {

--- a/script.js
+++ b/script.js
@@ -4406,40 +4406,8 @@ function hideCollectionPage() {
 }
 
 function setupFloatingButton() {
-    // Create floating "Shop Bestsellers" button
-    const floatingButton = document.createElement('div');
-    floatingButton.className = 'floating-shop-btn';
-    floatingButton.innerHTML = `
-        <button class="shop-bestsellers-btn">
-            <i class="fas fa-star"></i>
-            Shop Bestsellers
-        </button>
-    `;
-
-    // Add to collection page
-    const collectionPage = document.getElementById('collectionPage');
-    if (collectionPage) {
-        collectionPage.appendChild(floatingButton);
-
-        // Add click handler
-        const btn = floatingButton.querySelector('.shop-bestsellers-btn');
-        btn.addEventListener('click', () => {
-            // Filter to show bestsellers
-            const sortFilter = document.getElementById('sortFilter');
-            if (sortFilter) {
-                sortFilter.value = 'bestsellers';
-                sortProducts('bestsellers');
-            }
-
-            // Scroll to products
-            const productsSection = document.querySelector('.collection-products');
-            if (productsSection) {
-                productsSection.scrollIntoView({ behavior: 'smooth' });
-            }
-
-            showNotification('Showing bestsellers!', 'success');
-        });
-    }
+    // Floating button removed — no-op to keep backward compatibility
+    return;
 }
 
 function setupQuickActions() {

--- a/script.js
+++ b/script.js
@@ -3969,7 +3969,7 @@ function getCollectionData(collectionType) {
         winter: {
             title: 'Winter Collection ❄️',
             tagline: 'Explore cozy coats, chic sweaters, and stylish accessories designed to keep you warm and elegant this season.',
-            heroImage: 'https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2Fc4019445ace94cc59e8b63356e89694e?format=webp&width=1200',
+            heroImage: 'https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2F3f2c6aba195c4e98b9eae1efd859a679?format=webp&width=1200',
             theme: 'winter'
         },
         spring: {
@@ -4049,7 +4049,7 @@ function generateCollectionProducts(collectionType) {
         { name: 'Cashmere Turtleneck Sweater', price: 2899, category: 'sweaters', rating: '★★★★☆', image: 'https://cdn.builder.io/api/v1/image/assets%2F4797038dfeab418e80d0045aa34c21d8%2Fcd41764914f3435db0789865df8be918?format=webp&width=400' },
         { name: 'Quilted Puffer Jacket', price: 3499, category: 'jackets', rating: '★��★★★', image: 'https://cdn.builder.io/api/v1/image/assets%2F4797038dfeab418e80d0045aa34c21d8%2F849f7f09fb5840d7b25e7cdc865cdaa9?format=webp&width=400' },
         { name: 'Knit Winter Dress', price: 2199, category: 'dresses', rating: '★★★★☆', image: 'https://cdn.builder.io/api/v1/image/assets%2F4797038dfeab418e80d0045aa34c21d8%2F9915d20cfed848ec961a57e0b81de98d?format=webp&width=400' },
-        { name: 'Leather Winter Gloves', price: 899, category: 'accessories', rating: '★★���★★', image: 'https://cdn.builder.io/api/v1/image/assets%2F4797038dfeab418e80d0045aa34c21d8%2F081e58fb86c541a9af4297f57d3809c0?format=webp&width=400' },
+        { name: 'Leather Winter Gloves', price: 899, category: 'accessories', rating: '★★�����★★', image: 'https://cdn.builder.io/api/v1/image/assets%2F4797038dfeab418e80d0045aa34c21d8%2F081e58fb86c541a9af4297f57d3809c0?format=webp&width=400' },
         { name: 'Designer Wool Scarf', price: 1299, category: 'accessories', rating: '★���★★☆', image: 'https://cdn.builder.io/api/v1/image/assets%2F4797038dfeab418e80d0045aa34c21d8%2F5eccc65dc3744b36bfe1a6bc749e0af5?format=webp&width=400' },
         { name: 'Premium Bomber Jacket', price: 3899, category: 'jackets', rating: '★��★★★', image: 'https://cdn.builder.io/api/v1/image/assets%2F4797038dfeab418e80d0045aa34c21d8%2F8c2b221fa19b42968096df5cef83e949?format=webp&width=400' },
         { name: 'Merino Wool Cardigan', price: 2499, category: 'sweaters', rating: '★★★★☆', image: 'https://cdn.builder.io/api/v1/image/assets%2F4797038dfeab418e80d0045aa34c21d8%2F341ff6d502c545c4b3ada70308c85526?format=webp&width=400' }

--- a/script.js
+++ b/script.js
@@ -3946,6 +3946,13 @@ function loadCollectionContent(collectionType) {
         collectionHero.style.backgroundRepeat = 'no-repeat';
         collectionHero.style.backgroundPosition = 'center';
         collectionHero.style.backgroundSize = 'cover';
+
+        // Make sure the overlay isn't using its own background image which would cover the hero
+        const overlayEl = collectionHero.querySelector('.collection-hero-overlay');
+        if (overlayEl) {
+            overlayEl.style.backgroundImage = 'none';
+            overlayEl.style.background = 'rgba(0,0,0,0.25)';
+        }
     }
 
     // Update active collection tab

--- a/script.js
+++ b/script.js
@@ -3975,7 +3975,7 @@ function getCollectionData(collectionType) {
         spring: {
             title: 'Spring Collection 2025',
             tagline: 'Fresh styles for the new season ahead',
-            heroImage: 'https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2Fc4e20bc9665d428fa8ea5a83b64eecb2?format=webp&width=1200',
+            heroImage: 'https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2F199ff3be0ea14a5d9d45748644314a9a?format=webp&width=800',
             theme: 'spring'
         },
         summer: {

--- a/script.js
+++ b/script.js
@@ -4105,7 +4105,7 @@ function setupCollectionPage() {
     setupCollectionFilters();
     setupCollectionSort();
     setupBackNavigation();
-    setupFloatingButton();
+    // setupFloatingButton();
     setupQuickActions();
 }
 
@@ -4581,7 +4581,7 @@ function setupCollectionPage() {
     setupCollectionFilters();
     setupCollectionSort();
     setupBackNavigation();
-    setupFloatingButton();
+    // setupFloatingButton();
     setupQuickActions();
     setupCarousels();
     setupWinterFeatures();

--- a/script.js
+++ b/script.js
@@ -3417,7 +3417,7 @@ const subcategoryItems = {
             originalPrice: '$150',
             image: 'https://images.unsplash.com/photo-1595950653106-6c9ebd614d3a?w=400&h=400&fit=crop&auto=format&q=90',
             category: 'SHOES',
-            rating: '���������★★☆'
+            rating: '�������★★☆'
         }
     ],
     'Handbags': [
@@ -3975,7 +3975,7 @@ function getCollectionData(collectionType) {
         spring: {
             title: 'Spring Collection 2025',
             tagline: 'Fresh styles for the new season ahead',
-            heroImage: 'https://cdn.builder.io/api/v1/image/assets%2Fa91527f2fe264920accbd14578b2df55%2F72f8c53f7fb240f78689e888234308cb?format=webp&width=1200',
+            heroImage: 'https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2Fc4e20bc9665d428fa8ea5a83b64eecb2?format=webp&width=1200',
             theme: 'spring'
         },
         summer: {

--- a/script.js
+++ b/script.js
@@ -3982,7 +3982,7 @@ function getCollectionData(collectionType) {
         spring: {
             title: 'Spring Collection 2025',
             tagline: 'Fresh styles for the new season ahead',
-            heroImage: 'https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2F199ff3be0ea14a5d9d45748644314a9a?format=webp&width=800',
+            heroImage: 'https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2F1347c4fb530240a98b59adb770e14288?format=webp&width=1200',
             theme: 'spring'
         },
         summer: {

--- a/script.js
+++ b/script.js
@@ -3486,7 +3486,7 @@ const subcategoryItems = {
             originalPrice: '$119',
             image: 'https://images.unsplash.com/photo-1473966968600-fa801b869a1a?w=400&h=400&fit=crop&auto=format&q=90',
             category: 'WOMEN FASHION',
-            rating: '★★★★★'
+            rating: '★��★★★'
         }
     ],
     'Lingerie': [
@@ -3969,7 +3969,7 @@ function getCollectionData(collectionType) {
         winter: {
             title: 'Winter Collection ❄️',
             tagline: 'Explore cozy coats, chic sweaters, and stylish accessories designed to keep you warm and elegant this season.',
-            heroImage: 'https://cdn.builder.io/api/v1/image/assets%2Fa91527f2fe264920accbd14578b2df55%2F15723a5439104d63b98f8303a1efcea3?format=webp&width=1200',
+            heroImage: 'https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2F3c02fdf40d2d4f1fa24b5876394ccd00?format=webp&width=1200',
             theme: 'winter'
         },
         spring: {

--- a/script.js
+++ b/script.js
@@ -3417,7 +3417,7 @@ const subcategoryItems = {
             originalPrice: '$150',
             image: 'https://images.unsplash.com/photo-1595950653106-6c9ebd614d3a?w=400&h=400&fit=crop&auto=format&q=90',
             category: 'SHOES',
-            rating: '�������★★☆'
+            rating: '���������★★☆'
         }
     ],
     'Handbags': [
@@ -3486,7 +3486,7 @@ const subcategoryItems = {
             originalPrice: '$119',
             image: 'https://images.unsplash.com/photo-1473966968600-fa801b869a1a?w=400&h=400&fit=crop&auto=format&q=90',
             category: 'WOMEN FASHION',
-            rating: '★��★★★'
+            rating: '★★★★★'
         }
     ],
     'Lingerie': [
@@ -3969,7 +3969,7 @@ function getCollectionData(collectionType) {
         winter: {
             title: 'Winter Collection ❄️',
             tagline: 'Explore cozy coats, chic sweaters, and stylish accessories designed to keep you warm and elegant this season.',
-            heroImage: 'https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2F3c02fdf40d2d4f1fa24b5876394ccd00?format=webp&width=1200',
+            heroImage: 'https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2Fc4019445ace94cc59e8b63356e89694e?format=webp&width=1200',
             theme: 'winter'
         },
         spring: {

--- a/styles.css
+++ b/styles.css
@@ -1707,6 +1707,11 @@ h3::after {
     border-radius: 20px;
 }
 
+/* Spring-specific lighter overlay for fresher look */
+.spring-theme .collection-hero::before {
+    background: linear-gradient(90deg, rgba(255,255,255,0.35) 0%, rgba(255,255,255,0.05) 60%);
+}
+
 .collection-hero-content {
     position: relative;
     z-index: 2;

--- a/styles.css
+++ b/styles.css
@@ -1697,6 +1697,48 @@ h3::after {
     border-radius: 15px;
 }
 
+/* Overlay styles for image hero */
+.collection-hero::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.15) 60%);
+    z-index: 1;
+    border-radius: 20px;
+}
+
+.collection-hero-content {
+    position: relative;
+    z-index: 2;
+    color: #fff;
+    padding: 3rem 2rem;
+    max-width: 640px;
+}
+
+.collection-title {
+    color: #fff;
+    font-size: 3rem;
+    line-height: 1.05;
+    margin-bottom: 0.75rem;
+    text-shadow: 0 6px 24px rgba(0,0,0,0.45);
+}
+
+.collection-tagline {
+    color: rgba(255,255,255,0.95);
+    font-size: 1.1rem;
+    margin-bottom: 1.25rem;
+}
+
+.collection-cta {
+    background: rgba(255,255,255,0.12);
+    border: 1px solid rgba(255,255,255,0.2);
+    color: #fff;
+    padding: 0.85rem 1.4rem;
+    border-radius: 999px;
+    cursor: pointer;
+    font-weight: 600;
+}
+
 .collection-navigation h3 {
     margin-bottom: 1rem;
     color: #333;

--- a/styles.css
+++ b/styles.css
@@ -5099,7 +5099,11 @@ h3.section-title {
 }
 
 .slide-2-bg {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 25%, #f093fb 50%, #f5576c 75%, #4facfe 100%);
+    background-image: url("https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2Fc6b8e450cc61421e859ab2ce51cd518b");
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: cover;
+    top: -9px;
 }
 
 .slide-3-bg {

--- a/styles.css
+++ b/styles.css
@@ -5091,7 +5091,10 @@ h3.section-title {
     left: 0;
     width: 100%;
     height: 100%;
-    background: linear-gradient(135deg, #ff9aa2 0%, #ffb7b2 25%, #ffdac1 50%, #e2f0cb 75%, #b5ead7 100%);
+    background-image: url("https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2Fcca823ec8b624ff18c3b92b218c4e021");
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: cover;
     z-index: 1;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -5100,7 +5100,10 @@ h3.section-title {
 }
 
 .slide-3-bg {
-    background: linear-gradient(135deg, #ffecd2 0%, #fcb69f 25%, #ff8a80 50%, #ff7043 75%, #bf360c 100%);
+    background-image: url("https://cdn.builder.io/api/v1/image/assets%2Fbc30722007ed4ce4a7b2c2bf9e5944d6%2F38f425d996794eeb8e734d4f2c204005");
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: cover;
 }
 
 .geometric-shape {


### PR DESCRIPTION
## Purpose

Based on the conversation history, the user wanted to implement seasonal collection banners that display when users click on different seasons (Winter, Spring, Summer). They also requested removal of certain content elements from the interface.

## Code changes

- **Added Spring collection hero styles**: Created new CSS classes for spring-themed banner with background image, layout, and styling
- **Updated hero image URLs**: Changed collection data to use new Builder.io image assets for Winter, Spring, and Summer collections
- **Removed slide content**: Eliminated slide content sections from all three carousel slides in the hero area
- **Updated slider backgrounds**: Replaced gradient backgrounds with specific background images for each slide
- **Simplified collection navigation**: Streamlined back button structure and removed autumn collection tab
- **Removed promotional elements**: Eliminated "Shop Best Deals" CTA section and floating bestsellers button
- **Enhanced collection hero logic**: Updated JavaScript to handle both image and background-image scenarios for collection heroes
- **Added overlay styling**: Implemented proper overlay effects for collection hero sections with theme-specific variationsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5f0703215b1841b7ab3edfaf5512ffc9/flare-zone)

👀 [Preview Link](https://5f0703215b1841b7ab3edfaf5512ffc9-flare-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5f0703215b1841b7ab3edfaf5512ffc9</projectId>-->
<!--<branchName>flare-zone</branchName>-->